### PR TITLE
Add compare Interface for "cache miss hit" error

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,6 +1,9 @@
 package rapidash
 
-import "golang.org/x/xerrors"
+import (
+	"go.knocknote.io/rapidash/server"
+	"golang.org/x/xerrors"
+)
 
 var (
 	ErrBeginTransaction            = xerrors.New("failed begin cache transaction. required single connection instance or nothing")
@@ -42,3 +45,27 @@ var (
 var (
 	ErrInvalidCacheKey = xerrors.New("invalid cache key")
 )
+
+func IsCacheMiss(err error) bool {
+	if xerrors.Is(err, ErrCacheMiss) {
+		return true
+	}
+	if xerrors.Is(err, server.ErrCacheMiss) {
+		return true
+	}
+	return false
+}
+
+func IsTimeout(err error) bool {
+	if xerrors.Is(err, server.ErrSetTimeout) {
+		return true
+	}
+	return false
+}
+
+func IsMaxIdleConnections(err error) bool {
+	if xerrors.Is(err, server.ErrSetMaxIdleConnections) {
+		return true
+	}
+	return false
+}

--- a/error.go
+++ b/error.go
@@ -57,15 +57,9 @@ func IsCacheMiss(err error) bool {
 }
 
 func IsTimeout(err error) bool {
-	if xerrors.Is(err, server.ErrSetTimeout) {
-		return true
-	}
-	return false
+	return xerrors.Is(err, server.ErrSetTimeout)
 }
 
 func IsMaxIdleConnections(err error) bool {
-	if xerrors.Is(err, server.ErrSetMaxIdleConnections) {
-		return true
-	}
-	return false
+	return xerrors.Is(err, server.ErrSetMaxIdleConnections)
 }

--- a/last_level_cache_test.go
+++ b/last_level_cache_test.go
@@ -1068,6 +1068,16 @@ func TestLLCTimeSlice(t *testing.T) {
 	}
 }
 
+func TestCacheMiss(t *testing.T) {
+	tx, err := cache.Begin()
+	NoError(t, err)
+	defer func() { NoError(t, tx.Rollback()) }()
+	var v int
+	if err := tx.Find("int", IntPtr(&v)); !IsCacheMiss(err) {
+		t.Fatalf("%+v", err)
+	}
+}
+
 func TestLLCDecodeError(t *testing.T) {
 	now := time.Now()
 	tx, err := cache.Begin()

--- a/query_builder.go
+++ b/query_builder.go
@@ -274,7 +274,7 @@ func (q *Queries) Len() int {
 func (q *Queries) Each(iter func(*Query) error) error {
 	for _, query := range q.queries {
 		if err := iter(query); err != nil {
-			if xerrors.Is(err, server.ErrCacheMiss) {
+			if IsCacheMiss(err) {
 				q.cacheMissQueries = append(q.cacheMissQueries, query)
 				continue
 			}
@@ -295,7 +295,7 @@ func (q *Queries) LoadValues(factory *ValueFactory, primaryKeyLoader func(IndexT
 	findPrimaryKeys := []server.CacheKey{}
 	for queryIter.Next() {
 		if err := queryIter.Error(); err != nil {
-			if xerrors.Is(err, server.ErrCacheMiss) {
+			if IsCacheMiss(err) {
 				q.cacheMissQueries = append(q.cacheMissQueries, queryIter.Query())
 				continue
 			}
@@ -314,7 +314,7 @@ func (q *Queries) LoadValues(factory *ValueFactory, primaryKeyLoader func(IndexT
 
 	for valueIter.Next() {
 		if err := valueIter.Error(); err != nil {
-			if xerrors.Is(err, server.ErrCacheMiss) {
+			if IsCacheMiss(err) {
 				if existsFirstPhaseCacheMissQuery {
 					query := queryIter.QueryByPrimaryKey(valueIter.PrimaryKey())
 					if _, exists := alreadyAddedCacheMissQueryMap[query]; !exists {

--- a/rapidash_test.go
+++ b/rapidash_test.go
@@ -127,8 +127,14 @@ func TestSetTimeout(t *testing.T) {
 		t.Run(fmt.Sprintf("TestSetTimeout:%v\n", i), func(t *testing.T) {
 			_, err := New(Timeout(tt.timeout))
 			if tt.expected == nil {
+				if IsTimeout(err) {
+					t.Fatal("unexpected condition")
+				}
 				NoError(t, err)
 			} else if !xerrors.Is(err, tt.expected) {
+				if !IsTimeout(err) {
+					t.Fatal("unexpected condition")
+				}
 				t.Fatalf("%+v", err)
 			}
 		})
@@ -154,8 +160,14 @@ func TestSetMaxIdleConnections(t *testing.T) {
 		t.Run(fmt.Sprintf("TestSetMaxIdleConnections:%v\n", i), func(t *testing.T) {
 			_, err := New(MaxIdleConnections(tt.maxIdle))
 			if tt.expected == nil {
+				if IsMaxIdleConnections(err) {
+					t.Fatal("unexpected condition")
+				}
 				NoError(t, err)
 			} else if !xerrors.Is(err, tt.expected) {
+				if !IsMaxIdleConnections(err) {
+					t.Fatal("unexpected condition")
+				}
 				t.Fatalf("%+v", err)
 			}
 		})

--- a/second_level_cache.go
+++ b/second_level_cache.go
@@ -248,7 +248,7 @@ func (c *SecondLevelCache) lockKey(tx *Tx, key server.CacheKey) error {
 	log.Add(tx.id, lockKey, value)
 	if err := c.cacheServer.Add(lockKey, bytes, c.opt.LockExpiration()); err != nil {
 		content, getErr := c.cacheServer.Get(lockKey)
-		if xerrors.Is(getErr, server.ErrCacheMiss) {
+		if IsCacheMiss(getErr) {
 			return xerrors.Errorf("fatal error. cannot add transaction key. but transaction key doesn't exist: %w", err)
 		}
 		if getErr != nil {


### PR DESCRIPTION
`LastLevelCache` ( like `tx.Find()` ) returns `server.ErrCacheMiss` if cannot find cache from server.

If should ignore this error by application, detect kind of error type on it by the following.

```go
if err := tx.Find("key", value); !rapidash.IsCacheMiss(err) {
    return err // unexpected error
}
```
