### PR TITLE
Ignore to negative cache key as primary key

### DIFF
--- a/query_builder.go
+++ b/query_builder.go
@@ -93,7 +93,9 @@ func (i *QueryIterator) Error() error {
 
 func (i *QueryIterator) SetPrimaryKey(primaryKey server.CacheKey) {
 	result := i.results[i.currentIndex]
-	result.primaryKeys = []server.CacheKey{primaryKey}
+	if primaryKey.String() != "" {
+		result.primaryKeys = []server.CacheKey{primaryKey}
+	}
 	i.primaryKeyToQueryMap[primaryKey] = result.query
 }
 
@@ -107,6 +109,9 @@ func (i *QueryIterator) SetPrimaryKeys(primaryKeys []server.CacheKey) {
 
 func (i *QueryIterator) SetPrimaryKeyWithKey(key, primaryKey server.CacheKey) {
 	result := i.results[i.keyToIndexMap[key]]
+	if primaryKey.String() != "" {
+		result.primaryKeys = []server.CacheKey{primaryKey}
+	}
 	result.primaryKeys = []server.CacheKey{primaryKey}
 	i.primaryKeyToQueryMap[primaryKey] = result.query
 }


### PR DESCRIPTION
If got negative cache as result of searching by unique key, primary key is empty .
So, I fixed to `Rapidash` doesn't push empty cache key to `primaryKeys` .