### PR TITLE
modify delete cache for create

### DIFF
--- a/query_builder.go
+++ b/query_builder.go
@@ -94,11 +94,6 @@ func (i *QueryIterator) Error() error {
 func (i *QueryIterator) SetPrimaryKey(tx *Tx, primaryKey server.CacheKey) {
 	result := i.results[i.currentIndex]
 	if primaryKey != nil && primaryKey.String() != "" {
-		if _, exists := tx.stash.oldKey[primaryKey.String()]; exists {
-			// need lookup db
-			i.SetErrorWithKey(primaryKey, server.ErrCacheMiss)
-			return
-		}
 		result.primaryKeys = []server.CacheKey{primaryKey}
 	}
 	i.primaryKeyToQueryMap[primaryKey] = result.query

--- a/query_builder.go
+++ b/query_builder.go
@@ -91,7 +91,7 @@ func (i *QueryIterator) Error() error {
 	return i.results[i.currentIndex].err
 }
 
-func (i *QueryIterator) SetPrimaryKey(tx *Tx, primaryKey server.CacheKey) {
+func (i *QueryIterator) SetPrimaryKey(primaryKey server.CacheKey) {
 	result := i.results[i.currentIndex]
 	if primaryKey != nil && primaryKey.String() != "" {
 		result.primaryKeys = []server.CacheKey{primaryKey}

--- a/query_builder.go
+++ b/query_builder.go
@@ -91,9 +91,14 @@ func (i *QueryIterator) Error() error {
 	return i.results[i.currentIndex].err
 }
 
-func (i *QueryIterator) SetPrimaryKey(primaryKey server.CacheKey) {
+func (i *QueryIterator) SetPrimaryKey(tx *Tx, primaryKey server.CacheKey) {
 	result := i.results[i.currentIndex]
 	if primaryKey != nil && primaryKey.String() != "" {
+		if _, exists := tx.stash.oldKey[primaryKey.String()]; exists {
+			// need lookup db
+			i.SetErrorWithKey(primaryKey, server.ErrCacheMiss)
+			return
+		}
 		result.primaryKeys = []server.CacheKey{primaryKey}
 	}
 	i.primaryKeyToQueryMap[primaryKey] = result.query

--- a/second_level_cache.go
+++ b/second_level_cache.go
@@ -1181,7 +1181,7 @@ func (c *SecondLevelCache) deleteKeyByQueryBuilder(tx *Tx, builder *QueryBuilder
 		case IndexTypeUniqueKey:
 			for iter.Next() {
 				if err := c.deleteOldKey(tx, iter.Key()); err != nil {
-					return xerrors.Errorf("failed to delete unique key: %w", err)
+					return xerrors.Errorf("failed to delete old key: %w", err)
 				}
 			}
 		case IndexTypeKey:

--- a/tx_test.go
+++ b/tx_test.go
@@ -388,6 +388,14 @@ func TestTx_CreateByTableContext(t *testing.T) {
 		id, err := tx.CreateByTableContext(context.Background(), "user_logins", userLogin)
 		NoError(t, err)
 		NotEqualf(t, id, 0, "last insert id is zero")
+		var findUserFromSLCByPrimaryKey UserLogin
+		builder := NewQueryBuilder("user_logins").Eq("id", uint64(0))
+		tx.FindByQueryBuilder(builder, &findUserFromSLCByPrimaryKey)
+		Equal(t, findUserFromSLCByPrimaryKey.ID, userLogin.ID)
+		var findUserFromSLCByUniqueKey UserLogin
+		builder = NewQueryBuilder("user_logins").Eq("user_id", uint64(0)).Eq("user_session_id", uint64(1000))
+		tx.FindByQueryBuilder(builder, &findUserFromSLCByUniqueKey)
+		Equal(t, findUserFromSLCByPrimaryKey.ID, userLogin.ID)
 		NoError(t, tx.Commit())
 	})
 	t.Run("create by unknown table", func(t *testing.T) {

--- a/tx_test.go
+++ b/tx_test.go
@@ -390,11 +390,11 @@ func TestTx_CreateByTableContext(t *testing.T) {
 		NotEqualf(t, id, 0, "last insert id is zero")
 		var findUserFromSLCByPrimaryKey UserLogin
 		builder := NewQueryBuilder("user_logins").Eq("id", uint64(0))
-		tx.FindByQueryBuilder(builder, &findUserFromSLCByPrimaryKey)
+		NoError(t, tx.FindByQueryBuilder(builder, &findUserFromSLCByPrimaryKey))
 		Equal(t, findUserFromSLCByPrimaryKey.ID, userLogin.ID)
 		var findUserFromSLCByUniqueKey UserLogin
 		builder = NewQueryBuilder("user_logins").Eq("user_id", uint64(0)).Eq("user_session_id", uint64(1000))
-		tx.FindByQueryBuilder(builder, &findUserFromSLCByUniqueKey)
+		NoError(t, tx.FindByQueryBuilder(builder, &findUserFromSLCByUniqueKey))
 		Equal(t, findUserFromSLCByPrimaryKey.ID, userLogin.ID)
 		NoError(t, tx.Commit())
 	})


### PR DESCRIPTION
Modify delete cache for create.
Add to oldKey when creating, and reference it when primary key searching and unique key searching.

