### PR TITLE
Support Tx commit callback function

### DIFF
--- a/rapidash.go
+++ b/rapidash.go
@@ -599,8 +599,7 @@ func (tx *Tx) commitAfterProcess(queries []*PendingQuery) error {
 			if err := tx.afterCommitSuccessCallback(); err != nil {
 				errs = append(errs, err.Error())
 			}
-		}
-		if tx.r.opt.afterCommitSuccessCallback != nil {
+		} else if tx.r.opt.afterCommitSuccessCallback != nil {
 			if err := tx.r.opt.afterCommitSuccessCallback(tx); err != nil {
 				errs = append(errs, err.Error())
 			}

--- a/rapidash_test.go
+++ b/rapidash_test.go
@@ -184,6 +184,32 @@ func TestCommit(t *testing.T) {
 	Error(t, tx.CommitDBOnly())
 }
 
+func TestCommitCallback(t *testing.T) {
+	txConn, err := conn.Begin()
+	NoError(t, err)
+	tx, err := cache.Begin(txConn)
+	NoError(t, err)
+
+	var i, j int
+	tx.BeforeCommitCallback(func(queries []*QueryLog) error {
+		i = 10
+		j = 10
+		return nil
+	})
+	tx.AfterCommitCallback(func() error {
+		j = 20
+		return nil
+	}, func(logs []*QueryLog) error {
+		return nil
+	})
+
+	Equal(t, i, 0)
+	NoError(t, tx.CommitDBOnly())
+	NoError(t, tx.CommitCacheOnly())
+	Equal(t, i, 10)
+	Equal(t, j, 20)
+}
+
 func TestRollback(t *testing.T) {
 	txConn, err := conn.Begin()
 	NoError(t, err)


### PR DESCRIPTION
Implements `before/after commit callback func` in `Tx` scope.

If you call `Tx.BeforeCommitCallback(cb)`(or `Tx.AfterCommitCallback(scb, fcb)`), `Rapidash` uses `callback of Tx` preferentially over `callback of Rapidash`.