### PR TITLE
Fix lock and expiration

### DIFF
--- a/last_level_cache.go
+++ b/last_level_cache.go
@@ -82,9 +82,11 @@ func (c *LastLevelCache) Create(tx *Tx, tag, key string, value Type, expiration 
 	}
 	keyStr := cacheKey.String()
 	tx.stash.lastLevelCacheKeyToBytes[keyStr] = content
-	if _, exists := tx.pendingQueries[keyStr]; !exists {
-		if err := c.lockKey(tx, cacheKey, expiration); err != nil {
-			return xerrors.Errorf("failed to lock key: %w", err)
+	if c.opt.pessimisticLock {
+		if _, exists := tx.pendingQueries[keyStr]; !exists {
+			if err := c.lockKey(tx, cacheKey, expiration); err != nil {
+				return xerrors.Errorf("failed to lock key: %w", err)
+			}
 		}
 	}
 	var addrStr string
@@ -139,9 +141,11 @@ func (c *LastLevelCache) Update(tx *Tx, tag, key string, value Type, expiration 
 		return xerrors.Errorf("failed to get cacheKey: %w", err)
 	}
 	keyStr := cacheKey.String()
-	if _, exists := tx.pendingQueries[keyStr]; !exists {
-		if err := c.lockKey(tx, cacheKey, expiration); err != nil {
-			return xerrors.Errorf("failed to lock key: %w", err)
+	if c.opt.pessimisticLock {
+		if _, exists := tx.pendingQueries[keyStr]; !exists {
+			if err := c.lockKey(tx, cacheKey, expiration); err != nil {
+				return xerrors.Errorf("failed to lock key: %w", err)
+			}
 		}
 	}
 	var addrStr string

--- a/last_level_cache.go
+++ b/last_level_cache.go
@@ -84,7 +84,7 @@ func (c *LastLevelCache) Create(tx *Tx, tag, key string, value Type, expiration 
 	tx.stash.lastLevelCacheKeyToBytes[keyStr] = content
 	if c.opt.pessimisticLock {
 		if _, exists := tx.pendingQueries[keyStr]; !exists {
-			if err := c.lockKey(tx, cacheKey, expiration); err != nil {
+			if err := c.lockKey(tx, cacheKey, c.opt.lockExpiration); err != nil {
 				return xerrors.Errorf("failed to lock key: %w", err)
 			}
 		}
@@ -143,7 +143,7 @@ func (c *LastLevelCache) Update(tx *Tx, tag, key string, value Type, expiration 
 	keyStr := cacheKey.String()
 	if c.opt.pessimisticLock {
 		if _, exists := tx.pendingQueries[keyStr]; !exists {
-			if err := c.lockKey(tx, cacheKey, expiration); err != nil {
+			if err := c.lockKey(tx, cacheKey, c.opt.lockExpiration); err != nil {
 				return xerrors.Errorf("failed to lock key: %w", err)
 			}
 		}

--- a/rapidash_test.go
+++ b/rapidash_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestServerChanging(t *testing.T) {
 	t.Run("remove and add server", func(t *testing.T) {
-		cache, err := New(ServerAddrs([]string{"localhost:11211"}), MaxIdleConnections(1000), Timeout(200*time.Millisecond))
+		cache, err := New(ServerAddrs([]string{"localhost:11211"}), MaxIdleConnections(1000), Timeout(200*time.Millisecond), LastLevelCachePessimisticLock(true))
 		NoError(t, err)
 		tx, err := cache.Begin()
 		NoErrorf(t, err, "cannot begin cache transaction")
@@ -24,7 +24,7 @@ func TestServerChanging(t *testing.T) {
 	})
 
 	t.Run("remove and add only slc server", func(t *testing.T) {
-		cache, err := New(ServerAddrs([]string{"localhost:11211"}), MaxIdleConnections(1000), Timeout(200*time.Millisecond))
+		cache, err := New(ServerAddrs([]string{"localhost:11211"}), MaxIdleConnections(1000), Timeout(200*time.Millisecond), LastLevelCachePessimisticLock(true))
 		NoError(t, err)
 		NoError(t, cache.WarmUp(conn, userLoginType(), false))
 		tx, err := cache.Begin(conn)
@@ -43,7 +43,7 @@ func TestServerChanging(t *testing.T) {
 	})
 
 	t.Run("remove and add only llc server", func(t *testing.T) {
-		cache, err := New(ServerAddrs([]string{"localhost:11211"}), MaxIdleConnections(1000), Timeout(200000000000))
+		cache, err := New(ServerAddrs([]string{"localhost:11211"}), MaxIdleConnections(1000), Timeout(200000000000), LastLevelCachePessimisticLock(true))
 		NoError(t, err)
 		tx, err := cache.Begin()
 		NoErrorf(t, err, "cannot begin cache transaction")

--- a/second_level_cache.go
+++ b/second_level_cache.go
@@ -377,9 +377,15 @@ func (c *SecondLevelCache) update(tx *Tx, key server.CacheKey, value []byte, log
 		},
 		fn: func() error {
 			log.Update(tx.id, SLCServer, key, logenc)
+			casID := uint64(0)
+			if c.opt.OptimisticLock() {
+				casID = tx.stash.casIDs[key.String()]
+			}
 			if err := c.cacheServer.Set(&server.CacheStoreRequest{
 				Key:   key,
 				Value: value,
+				Expiration: c.opt.Expiration(),
+				CasID: casID,
 			}); err != nil {
 				return xerrors.Errorf("failed to update cache: %w", err)
 			}


### PR DESCRIPTION
Updating Cache In `SecondLevelCache` and `LastLevelCache`, enable to `Optimistic/PessimisticLock` and `Expiration` option .