### PR TITLE
Install golangci-lint by binary release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - run:
           name: Install Lint tool
           command: |
-            go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+            curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.21.0
       - run:
           name: Run golangci-lint
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - run:
           name: Install Lint tool
           command: |
-            curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.21.0
+            curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.21.0
       - run:
           name: Run golangci-lint
           command: |


### PR DESCRIPTION
`golangci-lint` developer says: `Please, do not install golangci-lint by go get`
https://github.com/golangci/golangci-lint#go-get

So, use binary instead of `go get`