### PR TITLE
Recalculation pk key hash if shard opt is nil

### DIFF
--- a/second_level_cache.go
+++ b/second_level_cache.go
@@ -532,7 +532,11 @@ func (c *SecondLevelCache) decodePrimaryKey(content []byte, flags uint32) (serve
 	if err != nil {
 		return nil, xerrors.Errorf("failed to decode primary key: %w", err)
 	}
-	return &CacheKey{key: primaryKey, hash: flags}, nil
+	hash := flags
+	if c.opt.shardKey == nil {
+		hash = NewStringValue(primaryKey).Hash()
+	}
+	return &CacheKey{key: primaryKey, hash: hash}, nil
 }
 
 func (c *SecondLevelCache) decodeMultiplePrimaryKeys(content []byte, flags uint32) ([]server.CacheKey, error) {
@@ -548,7 +552,11 @@ func (c *SecondLevelCache) decodeMultiplePrimaryKeys(content []byte, flags uint3
 		if err := dec.DecodeString(&v); err != nil {
 			return nil, xerrors.Errorf("failed to decode string: %w", err)
 		}
-		primaryKeys[i] = &CacheKey{key: v, hash: flags}
+		hash := flags
+		if c.opt.shardKey == nil {
+			hash = NewStringValue(v).Hash()
+		}
+		primaryKeys[i] = &CacheKey{key: v, hash: hash}
 	}
 	return primaryKeys, nil
 }


### PR DESCRIPTION
When call `FindByQueryBuilder` with queryBuilder used uq key or key, `rapidash` call `decodeMultiplePrimaryKeys` or `decodePrimaryKey` function.
Flags in arguments of this function is uq key's hash or key's hash value not pk's hash value.
So need to recalculation if opt shardKey is nil.