### PR TITLE
Add locking read option to query builder

### DIFF
--- a/second_level_cache.go
+++ b/second_level_cache.go
@@ -717,7 +717,7 @@ func (c *SecondLevelCache) setPrimaryKeysByKeys(tx *Tx, queryIter *QueryIterator
 }
 
 func (c *SecondLevelCache) findValuesByCache(tx *Tx, builder *QueryBuilder, queries *Queries) (*StructSliceValue, error) {
-	if builder.isIgnoreCache {
+	if builder.isIgnoreCache || builder.lockOpt != nil {
 		queries.cacheMissQueries = queries.queries
 		return NewStructSliceValue(), nil
 	}

--- a/second_level_cache_test.go
+++ b/second_level_cache_test.go
@@ -1136,6 +1136,65 @@ func TestIndexColumnUpdateByPrimaryKey(t *testing.T) {
 	}
 }
 
+func TestLockingRead(t *testing.T) {
+	NoError(t, initUserLoginTable(conn))
+	NoError(t, initCache(conn, CacheServerTypeMemcached))
+	slc := NewSecondLevelCache(userLoginType(), cache.cacheServer, TableOption{})
+	NoError(t, slc.cacheServer.Flush())
+	NoError(t, slc.WarmUp(conn))
+
+	txConn, err := conn.Begin()
+	NoError(t, err)
+	tx, err := cache.Begin(txConn)
+	NoError(t, err)
+
+	// store cache to stash
+	{
+		builder := NewQueryBuilder("user_logins").Eq("user_id", uint64(1))
+
+		var userLogin UserLogin
+		NoError(t, slc.FindByQueryBuilder(context.Background(), tx, builder, &userLogin))
+		if userLogin.ID == 0 {
+			t.Fatal("failed to get cached value")
+		}
+		if userLogin.LoginParamID != 1 {
+			t.Fatal("invalid param")
+		}
+	}
+
+	// update cache another transaction
+	{
+		txConn, err := conn.Begin()
+		NoError(t, err)
+		tx, err := cache.Begin(txConn)
+		NoError(t, err)
+		updateParam := map[string]interface{}{
+			"login_param_id": uint64(2),
+		}
+		builder := NewQueryBuilder("user_logins").Eq("id", uint64(1))
+		NoError(t, slc.UpdateByQueryBuilder(context.Background(), tx, builder, updateParam))
+		NoError(t, tx.Commit())
+	}
+
+	// repeatable read.
+	// in this case, cannot get updated value in normal query,
+	// but if use locking read query, could read updated value.
+	{
+		builder := NewQueryBuilder("user_logins").Eq("user_id", uint64(1)).ForUpdate()
+
+		var userLogin UserLogin
+		NoError(t, slc.FindByQueryBuilder(context.Background(), tx, builder, &userLogin))
+		if userLogin.ID == 0 {
+			t.Fatal("failed to get cached value")
+		}
+		if userLogin.LoginParamID != 2 {
+			t.Fatal("invalid param")
+		}
+	}
+
+	NoError(t, tx.Commit())
+}
+
 func TestDeleteByQueryBuilder(t *testing.T) {
 	for cacheServerType := range []CacheServerType{CacheServerTypeMemcached, CacheServerTypeRedis} {
 		testDeleteByQueryBuilder(t, CacheServerType(cacheServerType))


### PR DESCRIPTION
If you want to use `FOR UPDATE` in a `SELECT` query,   
it can be worked with the `(*QueryBuilder) .ForUpdate()` API.