### PR TITLE
Fix ParseUint bit size

### DIFF
--- a/server/memcache.go
+++ b/server/memcache.go
@@ -443,7 +443,7 @@ func scanGetResponseLine(line []byte, it *Item) (size int, err error) {
 			}
 			state = StateCasID
 		case StateCasID:
-			casID, err := strconv.ParseUint(s, 10, 32)
+			casID, err := strconv.ParseUint(s, 10, 64)
 			if err != nil {
 				return size, err
 			}


### PR DESCRIPTION
Use 64 bit size in `strconv.ParseUint` because CAS's type is uint64. 
