### PR TITLE
Added cache control for tags and its tests

### DIFF
--- a/assert_test.go
+++ b/assert_test.go
@@ -47,33 +47,3 @@ func NotEqualf(t *testing.T, src interface{}, dst interface{}, msg string, args 
 		t.Fatalf("equal %v and %v. %s", src, dst, fmt.Sprintf(msg, args...))
 	}
 }
-
-func IsNil(t *testing.T, src interface{}) {
-	IsNilf(t, src, "")
-}
-
-// reference: https://github.com/stretchr/testify/blob/v1.5.1/assert/assertions.go#L507
-func IsNilf(t *testing.T, src interface{}, msg string, args ...interface{}) {
-	if src == nil {
-		return
-	}
-	value := reflect.ValueOf(src)
-	if value.IsNil() {
-		return
-	}
-
-	kind := value.Kind()
-	kinds := []reflect.Kind{
-		reflect.Chan, reflect.Func,
-		reflect.Interface, reflect.Map,
-		reflect.Ptr, reflect.Slice,
-	}
-
-	for i := 0; i < len(kinds); i++ {
-		if kind == kinds[i] {
-			return
-		}
-	}
-
-	t.Fatalf("not equal to nil %v. %s", src, fmt.Sprintf(msg, args...))
-}

--- a/assert_test.go
+++ b/assert_test.go
@@ -47,3 +47,33 @@ func NotEqualf(t *testing.T, src interface{}, dst interface{}, msg string, args 
 		t.Fatalf("equal %v and %v. %s", src, dst, fmt.Sprintf(msg, args...))
 	}
 }
+
+func IsNil(t *testing.T, src interface{}) {
+	IsNilf(t, src, "")
+}
+
+// reference: https://github.com/stretchr/testify/blob/v1.5.1/assert/assertions.go#L507
+func IsNilf(t *testing.T, src interface{}, msg string, args ...interface{}) {
+	if src == nil {
+		return
+	}
+	value := reflect.ValueOf(src)
+	if value.IsNil() {
+		return
+	}
+
+	kind := value.Kind()
+	kinds := []reflect.Kind{
+		reflect.Chan, reflect.Func,
+		reflect.Interface, reflect.Map,
+		reflect.Ptr, reflect.Slice,
+	}
+
+	for i := 0; i < len(kinds); i++ {
+		if kind == kinds[i] {
+			return
+		}
+	}
+
+	t.Fatalf("not equal to nil %v. %s", src, fmt.Sprintf(msg, args...))
+}

--- a/config_test.go
+++ b/config_test.go
@@ -133,13 +133,19 @@ func TestConfig(t *testing.T) {
 
 					t.Run("config should have nil values", func(t *testing.T) {
 						tagCacheControlConfig := (*cfg.LLC.Tags)[tagName].CacheControl
-						IsNilf(t, tagCacheControlConfig, "should be nil")
+						if tagCacheControlConfig != nil {
+							t.Fatal("should be nil")
+						}
 					})
 
 					t.Run("options should have nil values", func(t *testing.T) {
 						tagOption := cache.lastLevelCache.opt.tagOpt[tagName]
-						IsNilf(t, tagOption.optimisticLock, "should be nil")
-						IsNilf(t, tagOption.pessimisticLock, "should be nil")
+						if tagOption.optimisticLock != nil {
+							t.Fatal("should be nil")
+						}
+						if tagOption.pessimisticLock != nil {
+							t.Fatal("should be nil")
+						}
 					})
 
 					t.Run("should retrieve last created value", func(t *testing.T) {

--- a/last_level_cache.go
+++ b/last_level_cache.go
@@ -81,14 +81,20 @@ func (c *LastLevelCache) shouldPessimisticLock(tag string) bool {
 	if !exists {
 		return c.opt.pessimisticLock
 	}
-	return opt.pessimisticLock
+	if opt.pessimisticLock == nil {
+		return c.opt.pessimisticLock
+	}
+	return *opt.pessimisticLock
 }
 func (c *LastLevelCache) shouldOptimisticLock(tag string) bool {
 	opt, exists := c.opt.tagOpt[tag];
 	if !exists {
 		return c.opt.optimisticLock
 	}
-	return opt.optimisticLock
+	if opt.optimisticLock == nil {
+		return c.opt.optimisticLock
+	}
+	return *opt.optimisticLock
 }
 
 func (c *LastLevelCache) set(tx *Tx, tag string, cacheKey server.CacheKey, content []byte, expiration time.Duration) error {

--- a/option.go
+++ b/option.go
@@ -203,7 +203,7 @@ func LastLevelCacheTagLockExpiration(tag string, expiration time.Duration) Optio
 func LastLevelCacheTagOptimisticLock(tag string, enabled bool) OptionFunc {
 	return func(r *Rapidash) {
 		opt := r.opt.llcOpt.tagOpt[tag]
-		opt.optimisticLock = enabled
+		opt.optimisticLock = &enabled
 		r.opt.llcOpt.tagOpt[tag] = opt
 	}
 }
@@ -211,7 +211,7 @@ func LastLevelCacheTagOptimisticLock(tag string, enabled bool) OptionFunc {
 func LastLevelCacheTagPessimisticLock(tag string, enabled bool) OptionFunc {
 	return func(r *Rapidash) {
 		opt := r.opt.llcOpt.tagOpt[tag]
-		opt.pessimisticLock = enabled
+		opt.pessimisticLock = &enabled
 		r.opt.llcOpt.tagOpt[tag] = opt
 	}
 }

--- a/option.go
+++ b/option.go
@@ -199,3 +199,19 @@ func LastLevelCacheTagLockExpiration(tag string, expiration time.Duration) Optio
 		r.opt.llcOpt.tagOpt[tag] = opt
 	}
 }
+
+func LastLevelCacheTagOptimisticLock(tag string, enabled bool) OptionFunc {
+	return func(r *Rapidash) {
+		opt := r.opt.llcOpt.tagOpt[tag]
+		opt.optimisticLock = enabled
+		r.opt.llcOpt.tagOpt[tag] = opt
+	}
+}
+
+func LastLevelCacheTagPessimisticLock(tag string, enabled bool) OptionFunc {
+	return func(r *Rapidash) {
+		opt := r.opt.llcOpt.tagOpt[tag]
+		opt.pessimisticLock = enabled
+		r.opt.llcOpt.tagOpt[tag] = opt
+	}
+}

--- a/rapidash.go
+++ b/rapidash.go
@@ -126,8 +126,8 @@ type TagOption struct {
 	expiration      time.Duration
 	lockExpiration  time.Duration
 	ignoreStash     bool
-	optimisticLock  bool
-	pessimisticLock bool
+	optimisticLock  *bool
+	pessimisticLock *bool
 }
 
 type QueryLog struct {

--- a/rapidash.go
+++ b/rapidash.go
@@ -122,10 +122,12 @@ type LastLevelCacheOption struct {
 }
 
 type TagOption struct {
-	server         string
-	expiration     time.Duration
-	lockExpiration time.Duration
-	ignoreStash    bool
+	server          string
+	expiration      time.Duration
+	lockExpiration  time.Duration
+	ignoreStash     bool
+	optimisticLock  bool
+	pessimisticLock bool
 }
 
 type QueryLog struct {

--- a/testdata/cache.yml
+++ b/testdata/cache.yml
@@ -36,6 +36,18 @@ llc:
       server: localhost:11211
       lock_expiration: 90
       expiration: 0
+    cache_control_no_lock:
+      server: localhost:11211
+      cache_control:
+        optimistic_lock: false
+        pessimistic_lock: false
+    cache_control_lock:
+      server: localhost:11211
+      cache_control:
+        optimistic_lock: true
+        pessimistic_lock: true
+    cache_control_implicit:
+      server: localhost:11211
   cache_control:
     optimistic_lock: false
     pessimistic_lock: false


### PR DESCRIPTION
# Summary
This PR adds the cache control support for tags.
It enables both pessimistic and optimistic lock under user defined tag(s).

# Notice
One thing might breaks current behavior, is the default values of tag's cache control.

Before this feature, tags does not care any cache control but behaves like following the LLC cache control option.
But after this PR, it has falsy options for cache control by default.
So the users who set any of LLC cache control option to true, those users tagged cache become out of cache control unexpectedly.

# Test

- [x] passed  `go test .` on my local environment
- [x] passed  `go test -run TestConfig` on my local environment